### PR TITLE
fix: do not fail if value is undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "genson-js",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "main": "dist/index.js",
     "types": "dist/index.d.js",
     "author": "Aspecto.io",

--- a/src/schema-builder.ts
+++ b/src/schema-builder.ts
@@ -230,6 +230,7 @@ function isContainerSchema(schema: Schema): boolean {
 // FACADE
 
 export function createSchema(value: any, options?: SchemaGenOptions): Schema {
+    if (typeof value === 'undefined') value = null;
     const clone = JSON.parse(JSON.stringify(value));
     return createSchemaFor(clone, options);
 }

--- a/tests/schema-builder.spec.ts
+++ b/tests/schema-builder.spec.ts
@@ -38,6 +38,11 @@ describe('SchemaBuilder', () => {
                 const schema = createSchema({});
                 expect(schema).toEqual({ type: 'object' });
             });
+
+            it('should build schema for undefined', () => {
+                const schema = createSchema(undefined);
+                expect(schema).toEqual({ type: 'null' });
+            });
         });
 
         describe('arrays', () => {


### PR DESCRIPTION
It fixes the issue I found in the logs of api-tests:
```
   "error"  : {
     "name"  :  "SyntaxError" ,
     "message"  :  "Unexpected token u in JSON at position 0" ,
```