### PR TITLE
fix(options): missing options when generating nested objects schema

### DIFF
--- a/src/schema-builder.ts
+++ b/src/schema-builder.ts
@@ -39,7 +39,7 @@ function createSchemaForObject(obj: Object, options?: SchemaGenOptions): Schema 
         };
     }
     const properties = Object.entries(obj).reduce((props, [key, val]) => {
-        props[key] = createSchemaFor(val);
+        props[key] = createSchemaFor(val, options);
         return props;
     }, {});
 

--- a/tests/schema-builder.spec.ts
+++ b/tests/schema-builder.spec.ts
@@ -166,6 +166,17 @@ describe('SchemaBuilder', () => {
                 });
                 expect(schema).toMatchSnapshot();
             });
+
+            it('should generate schema for nested object with props of different types w/o required', () => {
+                const schema = createSchema({ one: 1, two: { a: 'value' } }, { noRequired: true });
+                expect(schema).toEqual({
+                    type: 'object',
+                    properties: {
+                        one: { type: 'integer' },
+                        two: { type: 'object', properties: { a: { type: 'string' } } },
+                    },
+                });
+            });
         });
 
         describe('all cases combined', () => {


### PR DESCRIPTION
Hi @aspecto-system @mzahor @nirsky ,

When generating JSON Schema for nested objects with `noRequired` flag set to `true` in `options` object, I noticed that the required fields were still present in the nested schema.
This was because `options` was not passed along when recursively calling `createSchemaFor`, hence this fix.
We can do something similar with arrays too if you guyz are onboard wit that.

Thanks for this package !!