### PR TITLE
fix(schema-generation): missing options for arrays

### DIFF
--- a/src/schema-builder.ts
+++ b/src/schema-builder.ts
@@ -16,17 +16,17 @@ function createSchemaFor(value: any, options?: SchemaGenOptions): Schema {
                 return { type: ValueType.Null };
             }
             if (Array.isArray(value)) {
-                return createSchemaForArray(value);
+                return createSchemaForArray(value, options);
             }
             return createSchemaForObject(value, options);
     }
 }
 
-function createSchemaForArray(arr: Array<any>): Schema {
+function createSchemaForArray(arr: Array<any>, options?: SchemaGenOptions): Schema {
     if (arr.length === 0) {
         return { type: ValueType.Array };
     }
-    const elementSchemas = arr.map((value) => createSchemaFor(value));
+    const elementSchemas = arr.map((value) => createSchemaFor(value, options));
     const items = combineSchemas(elementSchemas);
     return { type: ValueType.Array, items };
 }

--- a/src/schema-builder.ts
+++ b/src/schema-builder.ts
@@ -39,7 +39,7 @@ function createSchemaForObject(obj: Object, options?: SchemaGenOptions): Schema 
         };
     }
     const properties = Object.entries(obj).reduce((props, [key, val]) => {
-        props[key] = createSchemaFor(val);
+        props[key] = createSchemaFor(val, options);
         return props;
     }, {});
 

--- a/tests/schema-builder.spec.ts
+++ b/tests/schema-builder.spec.ts
@@ -166,6 +166,17 @@ describe('SchemaBuilder', () => {
                 });
                 expect(schema).toMatchSnapshot();
             });
+
+            it('should generate schema for nested object with props of different types w/o required', () => {
+                const schema = createSchema({ one: 1, two: { a: 'value' } }, { noRequired: true });
+                expect(schema).toEqual({
+                    type: 'object',
+                    properties: {
+                        one: { type: 'integer' },
+                        two: { type: 'object', properties: { a: { type: 'string' } } },
+                    },
+                });
+            });
         });
 
         describe('all cases combined', () => {

--- a/tests/schema-builder.spec.ts
+++ b/tests/schema-builder.spec.ts
@@ -253,6 +253,26 @@ describe('SchemaBuilder', () => {
                     },
                 });
             });
+
+            it('should generate schema for array of objects w/o required', () => {
+                const schema = createSchema(
+                    [
+                        { one: 'a', two: 'b' },
+                        { one: 'aa', two: 'bb' },
+                    ],
+                    { noRequired: true }
+                );
+                expect(schema).toEqual({
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        properties: {
+                            one: { type: 'string' },
+                            two: { type: 'string' },
+                        },
+                    },
+                });
+            });
         });
 
         describe('prototype methods', () => {


### PR DESCRIPTION
In continuation of our quest to ensure schema generation without required fields with `noRequired` flag works as expected, this shall be the last missing piece !!

Currently, if we were to generate schema with `noRequired` like
```
createSchema([{ one: 'a', two: 'b' }, { one: 'aa', two: 'bb' }], { noRequired: true })
```
we'll get 
```
{
      type: 'array',
      items: {
            type: 'object',
            properties: {
                    one: { type: 'string' },
                    two: { type: 'string' },
            },
            required: ["one","two"]
       },
 }
```

with this change put in, we can now have 
```
{
      type: 'array',
      items: {
            type: 'object',
            properties: {
                    one: { type: 'string' },
                    two: { type: 'string' },
            },
       },
 }
```

@mzahor @YanivD @blumamir @aspecto-system Kindly Review !!