### PR TITLE
additionalProperties, nullable and minItems introduced

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "scripts": {
         "test": "jest",
         "tdd": "jest --watch",
-        "build": "tsc -p ./tsconfig-build.json",
+        "build": "cd \"$(dirname \"$0\")\" && tsc -p ./tsconfig-build.json",
         "prepublishOnly": "npm run build",
         "postinstall": "npm run build"
     },

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "scripts": {
         "test": "jest",
         "tdd": "jest --watch",
-        "build": "cd \"$(dirname \"$0\")\" && tsc -p ./tsconfig-build.json",
+        "build": "tsc -p tsconfig-build.json",
         "prepublishOnly": "npm run build",
-        "postinstall": "npm run build"
+        "prepare": "npm run build"
     },
     "devDependencies": {
         "@types/jest": "^27.5.1",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,14 @@
     "scripts": {
         "test": "jest",
         "tdd": "jest --watch",
-        "build": "tsc",
-        "prepublishOnly": "npm run build"
+        "build": "tsc -p ./tsconfig-build.json",
+        "prepublishOnly": "npm run build",
+        "postinstall": "npm run build"
     },
     "devDependencies": {
         "@types/jest": "^27.5.1",
         "@types/node": "^14.6.0",
+        "ajv": "^8.12.0",
         "jest": "^27.5.1",
         "ts-jest": "^27.1.5",
         "typescript": "^4.0.2"

--- a/src/schema-builder.ts
+++ b/src/schema-builder.ts
@@ -1,19 +1,23 @@
-import { ValueType, Schema, SchemaGenOptions } from './types';
+import { Schema, SchemaGenOptions, ValueType } from './types';
+
+
+const partition = <T>(arr: T[], criteria: (a: T) => boolean) => arr.reduce((acc, i) => {acc[criteria(i) ? 0 : 1].push(i); return acc}, [[], []]);
 
 function createSchemaFor(value: any, options?: SchemaGenOptions): Schema {
+    const nullable = options?.restrictiveNulls ? {nullable: false} : {};
     switch (typeof value) {
         case 'number':
             if (Number.isInteger(value)) {
-                return { type: ValueType.Integer };
+                return { type: ValueType.Integer, ...nullable };
             }
-            return { type: ValueType.Number };
+            return { type: ValueType.Number, ...nullable };
         case 'boolean':
-            return { type: ValueType.Boolean };
+            return { type: ValueType.Boolean, ...nullable };
         case 'string':
-            return { type: ValueType.String };
+            return { type: ValueType.String, ...nullable };
         case 'object':
             if (value === null) {
-                return { type: ValueType.Null };
+                return { type: ValueType.Null, ...(options?.restrictiveNulls ? { nullable: true } : {}) };
             }
             if (Array.isArray(value)) {
                 return createSchemaForArray(value, options);
@@ -23,19 +27,28 @@ function createSchemaFor(value: any, options?: SchemaGenOptions): Schema {
 }
 
 function createSchemaForArray(arr: Array<any>, options?: SchemaGenOptions): Schema {
+    const nullable = options?.restrictiveNulls ? {nullable: false} : {};
     if (arr.length === 0) {
-        return { type: ValueType.Array };
+        return { type: ValueType.Array, ...nullable};
     }
     const elementSchemas = arr.map((value) => createSchemaFor(value, options));
     const items = combineSchemas(elementSchemas);
-    return { type: ValueType.Array, items };
+    let minItems;
+    if(options?.restrictiveArrays) {
+        minItems = options.minItemsOverride ?? arr.length;
+    }
+    return { type: ValueType.Array, items, ...(minItems && { minItems }), ...nullable };
 }
 
 function createSchemaForObject(obj: Object, options?: SchemaGenOptions): Schema {
+    const nullable = options?.restrictiveNulls ? {nullable: false} : {};
+    const additionalProps = options?.additionalProperties ? {additionalProperties: true} : {};
     const keys = Object.keys(obj);
     if (keys.length === 0) {
         return {
             type: ValueType.Object,
+            ...nullable,
+            ...additionalProps,
         };
     }
     const properties = Object.entries(obj).reduce((props, [key, val]) => {
@@ -43,7 +56,7 @@ function createSchemaForObject(obj: Object, options?: SchemaGenOptions): Schema 
         return props;
     }, {});
 
-    const schema: Schema = { type: ValueType.Object, properties };
+    const schema: Schema = { type: ValueType.Object, properties, ...nullable, ...additionalProps };
     if (!options?.noRequired) {
         schema.required = keys;
     }
@@ -66,8 +79,6 @@ function combineSchemas(schemas: Schema[], options?: SchemaGenOptions): Schema {
         const type = unwrappedSchema.type as ValueType;
         if (schemasByType[type].length === 0 || isContainerSchema(unwrappedSchema)) {
             schemasByType[type].push(unwrappedSchema);
-        } else {
-            continue;
         }
     }
 
@@ -77,7 +88,7 @@ function combineSchemas(schemas: Schema[], options?: SchemaGenOptions): Schema {
         [ValueType.Number]: schemasByType[ValueType.Number][0],
         [ValueType.Integer]: schemasByType[ValueType.Integer][0],
         [ValueType.String]: schemasByType[ValueType.String][0],
-        [ValueType.Array]: combineArraySchemas(schemasByType[ValueType.Array]),
+        [ValueType.Array]: combineArraySchemas(schemasByType[ValueType.Array], options),
         [ValueType.Object]: combineObjectSchemas(schemasByType[ValueType.Object], options),
     };
 
@@ -89,21 +100,60 @@ function combineSchemas(schemas: Schema[], options?: SchemaGenOptions): Schema {
     const schemasFound = Object.values(resultSchemasByType).filter(Boolean);
     const multiType = schemasFound.length > 1;
     if (multiType) {
-        const wrapped = wrapAnyOfSchema({ anyOf: schemasFound });
-        return wrapped;
+        return wrapAnyOfSchema({ anyOf: schemasFound }, options);
     }
     return schemasFound[0] as Schema;
 }
 
-function combineArraySchemas(schemas: Schema[]): Schema {
+function combineArraySchemas(schemas: Schema[], options?: SchemaGenOptions): Schema {
     if (!schemas || schemas.length === 0) {
         return undefined;
     }
+    const nullableArr: boolean[] = [];
     const itemSchemas: Schema[] = [];
     for (const schema of schemas) {
+        nullableArr.push(schema.nullable ?? true);
         if (!schema.items) continue;
         const unwrappedSchemas = unwrapSchema(schema.items);
         itemSchemas.push(...unwrappedSchemas);
+    }
+
+    if(options?.restrictiveNulls && !options?.mergeToLessRestrictive) {
+        const firstSchema = schemas[0].items;
+        const allSame = schemas.reduce((acc, schema) => acc && isSameSchema(firstSchema, schema.items), true);
+
+        if(allSame && nullableArr.indexOf(false) > -1) {
+            return {...schemas[0], nullable: false};
+        }
+
+        const [nullable, nonNullable] = partition(schemas, s => s.nullable);
+        if(nonNullable.length > 0 && nullable.length > 0) {
+            return {
+                anyOf: [
+                    combineArraySchemas(nonNullable, options),
+                    combineArraySchemas(nullable, options),
+                ]
+            }
+        }
+    }
+
+    if (options?.mergeToLessRestrictive && schemas.length !== schemas.filter(schema => !!schema.items).length) {
+        return {
+            type: ValueType.Array,
+        };
+    }
+
+    let minItems = options?.minItemsOverride;
+    for (const schema of schemas) {
+        if (!schema.minItems) {
+            minItems = undefined;
+            break;
+        }
+        if(minItems === undefined) {
+            minItems = schema.minItems;
+        } else {
+            minItems = Math.min(minItems, schema.minItems);
+        }
     }
 
     if (itemSchemas.length === 0) {
@@ -111,35 +161,106 @@ function combineArraySchemas(schemas: Schema[]): Schema {
             type: ValueType.Array,
         };
     }
+
     const items = combineSchemas(itemSchemas);
     return {
         type: ValueType.Array,
         items,
+        ...(minItems && (minItems !== 0 ? { minItems } : {})),
+        ...(nullableArr.indexOf(false) > -1 ? {nullable: (!!options?.mergeToLessRestrictive && nullableArr.indexOf(true) > -1)} : {}),
     };
+}
+
+const isSameSchema = (schema1: Schema, schema2: Schema) => {
+    if(schema1 === undefined || schema2 === undefined) {
+        return schema1 === schema2;
+
+    }
+    if(schema1.type !== schema2.type) {
+        return false;
+    }
+    if(schema1.type === ValueType.Array) {
+        return isSameSchema(schema1.items, schema2.items);
+    }
+    if(schema1.type === ValueType.Object) {
+        const keys1 = Object.keys(schema1.properties);
+        const keys2 = Object.keys(schema2.properties);
+        if(keys1.length !== keys2.length) {
+            return false;
+        }
+        for(const key of keys1) {
+            if(!isSameSchema(schema1.properties[key], schema2.properties[key])) {
+                return false;
+            }
+        }
+        return true;
+    }
+    return true;
 }
 
 function combineObjectSchemas(schemas: Schema[], options?: SchemaGenOptions): Schema {
     if (!schemas || schemas.length === 0) {
         return undefined;
     }
+    const nullableArr: boolean[] = [];
+    schemas.forEach((schema) => {
+        nullableArr.push(schema.nullable ?? true);
+    })
+    const additionalProps: boolean[] = [];
+    schemas.forEach((schema) => {
+        additionalProps.push(schema.additionalProperties ?? true);
+    })
+    if(options?.restrictiveNulls && !options?.mergeToLessRestrictive) {
+        const [nullable, nonNullable] = partition(schemas, s => s.nullable ?? true);
+        if(nonNullable.length > 0 && nullable.length > 0) {
+            return {
+                anyOf: [
+                    combineObjectSchemas(nonNullable, options),
+                    combineObjectSchemas(nullable, options),
+                ]
+            }
+        }
+    }
     const allPropSchemas = schemas.map((s) => s.properties).filter(Boolean);
-    const schemasByProp: Record<string, Schema[]> = Object.create(null);
-    // const schemasByProp: Record<string, Schema[]> = {};
+    if(options?.mergeToLessRestrictive && allPropSchemas.length !== schemas.length) {
+        return {
+            type: ValueType.Object,
+            ...(nullableArr.indexOf(false) > -1 ? {nullable: (!!options?.mergeToLessRestrictive && nullableArr.indexOf(true) > -1)} : {}),
+            ...(additionalProps.indexOf(true) > -1 ?  {} : {additionalProperties: false}),
+        }
+    }
+    const schemasByProp: Record<string, Schema[][]> = Object.create(null);
     for (const propSchemas of allPropSchemas) {
         for (const [prop, schema] of Object.entries(propSchemas)) {
             if (!schemasByProp[prop]) {
                 schemasByProp[prop] = [];
             }
             const unwrappedSchemas = unwrapSchema(schema);
-            schemasByProp[prop].push(...unwrappedSchemas);
+            schemasByProp[prop].push(unwrappedSchemas);
         }
     }
 
-    const properties: Record<string, Schema> = Object.entries(schemasByProp).reduce((props, [prop, schemas]) => {
+    if(options?.mergeToLessRestrictive) {
+        for (const [prop, subschemas] of Object.entries(schemasByProp)) {
+            if(subschemas.length !== schemas.length) {
+                delete schemasByProp[prop];
+            }
+        }
+    }
+
+    const properties: Record<string, Schema> = Object.entries(schemasByProp).reduce((props, [prop, schemaArr]) => {
+        const schemas = schemaArr.reduce((acc, s) => [...acc, ...s], []);
         if (schemas.length === 1) {
             props[prop] = schemas[0];
         } else {
-            props[prop] = combineSchemas(schemas);
+            const combined = combineSchemas(schemas, options);
+            if(!(options?.restrictiveNulls ?? false)) {
+                const [nullable, nonNullable] = partition(schemas, s => s.nullable);
+                if(nonNullable.length > 0 && nullable.length > 0) {
+                    delete combined.nullable;
+                }
+            }
+            props[prop] = combined;
         }
         return props;
     }, {});
@@ -154,6 +275,15 @@ function combineObjectSchemas(schemas: Schema[], options?: SchemaGenOptions): Sc
         if (required.length > 0) {
             combinedSchema.required = required;
         }
+    }
+    if(nullableArr.indexOf(false) > -1) {
+        if (!(options?.mergeToLessRestrictive && nullableArr.indexOf(true) > -1)) {
+            combinedSchema.nullable = false;
+        }
+    }
+
+    if(additionalProps.indexOf(true) === -1) {
+        combinedSchema.additionalProperties = false;
     }
 
     return combinedSchema;
@@ -172,28 +302,66 @@ export function unwrapSchema(schema: Schema): Schema[] {
 
 export function unwrapSchemas(schemas: Schema[]): Schema[] {
     if (!schemas || schemas.length === 0) return [];
-    const unwrappedSchemas = schemas.flatMap((schema) => unwrapSchema(schema));
-    return unwrappedSchemas;
+    return schemas.flatMap((schema) => unwrapSchema(schema));
 }
 
-export function wrapAnyOfSchema(schema: Schema): Schema {
+export function wrapAnyOfSchema(schema: Schema, options?: SchemaGenOptions): Schema {
     const simpleSchemas = [];
     const complexSchemas = [];
+    let nullable: boolean = undefined;
     for (const subSchema of schema.anyOf) {
-        if (Array.isArray(subSchema.type)) {
-            simpleSchemas.push(...subSchema.type);
-        } else if (isSimpleSchema(subSchema)) {
-            simpleSchemas.push((subSchema as Schema).type);
+        if (isSimpleSchema(subSchema) && !options?.restrictiveNulls) {
+            if(Array.isArray(subSchema.type)) {
+                simpleSchemas.push(...subSchema.type);
+            } else {
+                simpleSchemas.push((subSchema as Schema).type);
+            }
+            nullable = true;
+        } else if (isSimpleSchema(subSchema) && options?.restrictiveNulls) {
+            if (nullable === undefined || nullable === true) {
+                if(Array.isArray(subSchema.type)) {
+                    simpleSchemas.push(...subSchema.type);
+                } else {
+                    simpleSchemas.push((subSchema as Schema).type);
+                }
+                nullable = true;
+            } else {
+                complexSchemas.push(subSchema);
+            }
+        } else if (isSimpleSchemaWithNullable(subSchema) && !options?.restrictiveNulls) {
+            if(Array.isArray(subSchema.type)) {
+                simpleSchemas.push(...subSchema.type);
+            } else {
+                simpleSchemas.push((subSchema as Schema).type);
+            }
+            nullable = nullable === undefined ? subSchema.nullable : nullable || subSchema.nullable;
+        } else if (isSimpleSchemaWithNullable(subSchema) && options?.restrictiveNulls) {
+            if (nullable === undefined) {
+                if(Array.isArray(subSchema.type)) {
+                    simpleSchemas.push(...subSchema.type);
+                } else {
+                    simpleSchemas.push((subSchema as Schema).type);
+                }
+                nullable = subSchema.nullable;
+            } else if (nullable === subSchema.nullable) {
+                if(Array.isArray(subSchema.type)) {
+                    simpleSchemas.push(...subSchema.type);
+                } else {
+                    simpleSchemas.push((subSchema as Schema).type);
+                }
+            } else {
+                complexSchemas.push(subSchema);
+            }
         } else {
             complexSchemas.push(subSchema);
         }
     }
     if (complexSchemas.length === 0) {
-        return { type: simpleSchemas };
+        return { type: simpleSchemas, ...(nullable === undefined ? {} : (nullable ? {} : {nullable})) };
     }
     const anyOf = [];
     if (simpleSchemas.length > 0) {
-        anyOf.push({ type: simpleSchemas.length > 1 ? simpleSchemas : simpleSchemas[0] });
+        anyOf.push({ type: simpleSchemas.length > 1 ? simpleSchemas : simpleSchemas[0], ...(nullable === undefined ? {} : (nullable ? {} : {nullable}))});
     }
     anyOf.push(...complexSchemas);
     return { anyOf };
@@ -212,15 +380,19 @@ function intersection(valuesArr: string[][]) {
             }
         }
     }
-    const result = Object.entries(counter)
+    return Object.entries(counter)
         .filter(([_, value]) => value === arrays.length)
         .map(([key]) => key);
-    return result;
 }
 
 function isSimpleSchema(schema: Schema): boolean {
     const keys = Object.keys(schema);
     return keys.length === 1 && keys[0] === 'type';
+}
+
+function isSimpleSchemaWithNullable(schema: Schema): boolean {
+    const keys = Object.keys(schema);
+    return keys.length === 2 && keys.indexOf('type') > -1 && keys.indexOf('nullable') > -1;
 }
 
 function isContainerSchema(schema: Schema): boolean {
@@ -237,14 +409,12 @@ export function createSchema(value: any, options?: SchemaGenOptions): Schema {
 }
 
 export function mergeSchemas(schemas: Schema[], options?: SchemaGenOptions): Schema {
-    const mergedSchema = combineSchemas(schemas, options);
-    return mergedSchema;
+    return combineSchemas(schemas, options);
 }
 
 export function extendSchema(schema: Schema, value: any, options?: SchemaGenOptions): Schema {
     const valueSchema = createSchema(value, options);
-    const mergedSchema = combineSchemas([schema, valueSchema], options);
-    return mergedSchema;
+    return combineSchemas([schema, valueSchema], options);
 }
 
 export function createCompoundSchema(values: any[], options?: SchemaGenOptions): Schema {

--- a/src/schema-comparator.ts
+++ b/src/schema-comparator.ts
@@ -1,7 +1,7 @@
 import { mergeSchemas, unwrapSchema } from './schema-builder';
-import { Schema, SchemaComparisonOptions } from './types';
+import { Schema, SchemaComparisonOptions, SchemaGenOptions } from './types';
 
-export function areSchemasEqual(schema1: Schema, schema2: Schema, options?: SchemaComparisonOptions): boolean {
+export function areSchemasEqual(schema1: Schema, schema2: Schema, options?: SchemaComparisonOptions & SchemaGenOptions): boolean {
     if (schema1 === undefined && schema2 === undefined) return true;
     if (schema1 === undefined || schema2 === undefined) return false;
 
@@ -20,43 +20,70 @@ export function areSchemasEqual(schema1: Schema, schema2: Schema, options?: Sche
         const s2 = sorted2[i];
 
         if (s1.type !== s2.type) return false;
-        if (!options?.ignoreRequired && !areArraysEqual(s1.required, s2.required)) return false;
-        if (!arePropsEqual(s1.properties, s2.properties, options)) return false;
+        if (!options?.ignoreRequired && !areArraysEqual(s1.required, s2.required, options?.subsetRequired ?? false)) return false;
+        if ((s1.nullable ?? true) !== (s2.nullable ?? true)) {
+            return false;
+        }
+        if ((s1.additionalProperties ?? true) !== (s2.additionalProperties ?? true)) {
+            return false;
+        }
+        if (!arePropsEqual(s1.properties, s2.properties, s2.additionalProperties ?? true, options)) return false;
         if (!areSchemasEqual(s1.items, s2.items, options)) return false;
     }
 
     return true;
 }
 
-function areArraysEqual(arr1: string[], arr2: string[]): boolean {
+function areArraysEqual(arr1: string[], arr2: string[], subsetRequired: boolean): boolean {
+    // if subsetRequired is true, arr2 must be more restrictive than arr1
     if (arr1 === undefined && arr2 === undefined) return true;
-    if (arr1 === undefined || arr2 === undefined) return false;
+    if (arr2 === undefined) return false;
+    if (arr1 === undefined && !subsetRequired) return false;
     const set1 = new Set(arr1);
     const set2 = new Set(arr2);
     const combined = new Set([...arr1, ...arr2]);
-    const areEqual = combined.size === set1.size && combined.size === set2.size;
-    return areEqual;
+    if(!subsetRequired) {
+        return combined.size === set1.size && combined.size === set2.size;
+    } else {
+        //this asymmetry is intentional, we want to make sure that arr2 is more restrictive than arr1
+        return combined.size === set2.size && combined.size >= set1.size;
+    }
 }
 
 function arePropsEqual(
     props1: Record<string, Schema>,
     props2: Record<string, Schema>,
-    options?: SchemaComparisonOptions
+    additionalProps: boolean,
+    options?: SchemaComparisonOptions & SchemaGenOptions
 ): boolean {
     if (props1 === undefined && props2 === undefined) return true;
     if (props1 === undefined || props2 === undefined) return false;
     const keys1 = Object.keys(props1);
     const keys2 = Object.keys(props2);
-    if (!areArraysEqual(keys1, keys2)) return false;
+    const nonNullableKeys1 = keys1.filter((k) => !(props1[k].nullable ?? true));
+    const nonNullableKeys2 = keys2.filter((k) => !(props2[k].nullable ?? true));
+    if (!areArraysEqual(keys1, keys2, additionalProps && (options?.subsetRequired ?? false))) return false;
+    if (!areArraysEqual(nonNullableKeys1, nonNullableKeys2, false)) return false;
     for (const key of keys1) {
         if (!areSchemasEqual(props1[key], props2[key], options)) return false;
     }
     return true;
 }
-
-export function isSubset(mainSchema: Schema, subSchema: Schema, options?: SchemaComparisonOptions): boolean {
-    const mergedSchema = mergeSchemas([mainSchema, subSchema]);
-    // console.log(JSON.stringify(mergedSchema, null, 4));
-    const isModified = areSchemasEqual(mergedSchema, mainSchema, options);
-    return isModified;
+/**
+ * Returns a bool if all the second schema's jsons are valid in the first schema too.
+ * So the subSchema is more restrictive than the mainSchema, but they are compatible.
+ *
+ * @param {Schema} mainSchema The less restrictive schema (superset).
+ * @param {Schema} subSchema The more restrictive schema (subset).
+ * @param {SchemaComparisonOptions & SchemaGenOptions} options additional options
+ * @return {boolean} true if the subSchema is a subset of the mainSchema.
+ *
+ * @example isSubset(
+ *                 { anyOf: [{ type: [ValueType.String, ValueType.Number] }] }, // valid: 1, 2, "a", "b"
+ *                 { anyOf: [{ type: ValueType.Number }] } // valid: 1, 2
+ *             ) === true
+ */
+export function isSubset(mainSchema: Schema, subSchema: Schema, options?: SchemaComparisonOptions & SchemaGenOptions): boolean {
+    const mergedSchema = mergeSchemas([mainSchema, subSchema], {...options, restrictiveNulls: true, mergeToLessRestrictive: true});
+    return areSchemasEqual(mainSchema, mergedSchema, { ...options, subsetRequired: true });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,12 +14,22 @@ export type Schema = {
     properties?: Record<string, Schema>;
     required?: string[];
     anyOf?: Array<Schema>;
+    additionalProperties?: boolean;
+    nullable?: boolean;
+    minItems?: number;
 };
 
 export type SchemaGenOptions = {
-    noRequired: boolean;
+    noRequired?: boolean;
+    additionalProperties?: boolean;
+    restrictiveArrays?: boolean;
+    minItemsOverride?: number;
+    restrictiveNulls?: boolean;
+    mergeToLessRestrictive?: boolean;
 };
 
 export type SchemaComparisonOptions = {
-    ignoreRequired: boolean;
+    ignoreRequired?: boolean;
+    subsetRequired?: boolean;
+
 };

--- a/tests/schema-builder.spec.ts
+++ b/tests/schema-builder.spec.ts
@@ -1,103 +1,208 @@
-import { createSchema, mergeSchemas, ValueType, extendSchema, createCompoundSchema } from '../src';
-import { pp } from './test-utils';
+import { createCompoundSchema, createSchema, extendSchema, mergeSchemas, ValueType } from '../src';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import Ajv from 'ajv';
 
+let ajv;
 describe('SchemaBuilder', () => {
+    beforeEach(() => {
+        ajv = new Ajv({ allowUnionTypes: true, verbose: true, strict: true });
+    });
     describe('generation', () => {
         describe('simple types', () => {
             it('should build schema for integer', () => {
-                const schema = createSchema(1);
+                const data = 1
+                const schema = createSchema(data);
                 expect(schema).toEqual({ type: 'integer' });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
 
             it('should build schema for number', () => {
-                const schema = createSchema(1.1);
+                const data = 1.1
+                const schema = createSchema(data);
                 expect(schema).toEqual({ type: 'number' });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
 
             it('should build schema for string', () => {
-                const schema = createSchema('some string');
+                const data = 'some string'
+                const schema = createSchema(data);
                 expect(schema).toEqual({ type: 'string' });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
 
             it('should build schema for null', () => {
-                const schema = createSchema(null);
+                const data = null;
+                const schema = createSchema(data);
                 expect(schema).toEqual({ type: 'null' });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
 
             it('should build schema for boolean', () => {
-                const schema = createSchema(false);
+                const data = false;
+                const schema = createSchema(data);
                 expect(schema).toEqual({ type: 'boolean' });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
 
             it('should build schema for array', () => {
-                const schema = createSchema([]);
+                const data = [];
+                const schema = createSchema(data);
                 expect(schema).toEqual({ type: 'array' });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
 
             it('should build schema for object', () => {
-                const schema = createSchema({});
+                const data = {};
+                const schema = createSchema(data);
                 expect(schema).toEqual({ type: 'object' });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
 
             it('should build schema for undefined', () => {
-                const schema = createSchema(undefined);
+                const data = undefined;
+                const schema = createSchema(data);
                 expect(schema).toEqual({ type: 'null' });
+                // Ajv does not validate undefined as nulls!
             });
         });
 
         describe('arrays', () => {
             it('it should generate schema for arrays of the same type', () => {
-                const schema = createSchema([1, 2, 3]);
+                const data = [1, 2, 3];
+                const schema = createSchema(data);
                 expect(schema).toEqual({ type: 'array', items: { type: 'integer' } });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
 
             it('it should generate schema for arrays of the same type with floats', () => {
-                const schema = createSchema([1, 2.1, 3]);
+                const data = [1, 2.1, 3];
+                const schema = createSchema(data);
                 expect(schema).toEqual({ type: 'array', items: { type: 'number' } });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
 
             it('it should generate schema for arrays of different primitive types', () => {
-                const schema = createSchema([1, 1.1, 'string', null, false, true]);
+                const data = [1, 1.1, 'string', null, false, true];
+                const schema = createSchema(data);
                 expect(schema).toEqual({ type: 'array', items: { type: ['null', 'boolean', 'number', 'string'] } });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
 
             it('it should generate schema for arrays of different primitive types and ints only', () => {
-                const schema = createSchema([1, 'string', null, false, true]);
+                const data = [1, 'string', null, false, true];
+                const schema = createSchema(data);
                 expect(schema).toEqual({ type: 'array', items: { type: ['null', 'boolean', 'integer', 'string'] } });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
+            });
+
+            it('it should add minItems if restrictiveArrays', () => {
+                const data = [1, 'string', null, false, true];
+                const schema = createSchema(data, {restrictiveArrays: true});
+                expect(schema).toEqual({ type: 'array', items: { type: ['null', 'boolean', 'integer', 'string'] }, minItems: 5 });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
+            });
+
+            it('it should add minItems if restrictiveArrays and minItemsOverride', () => {
+                const data = [1, 'string', null, false, true];
+                const schema = createSchema(data, {restrictiveArrays: true, minItemsOverride: 1});
+                expect(schema).toEqual({ type: 'array', items: { type: ['null', 'boolean', 'integer', 'string'] }, minItems: 1 });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
+            });
+
+            it('it should not add minItems if restrictiveArrays and/or minItemsOverride if the given array is empty', () => {
+                const data = [];
+                const schema = createSchema(data, {restrictiveArrays: true, minItemsOverride: 1});
+                expect(schema).toEqual({ type: 'array' });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
         });
 
         describe('objects', () => {
             it('it should generate schema for object with props of the same type', () => {
-                const schema = createSchema({ one: 1, two: 2 });
+                const data = { one: 1, two: 2 };
+                const schema = createSchema(data);
                 expect(schema).toEqual({
                     type: 'object',
                     properties: { one: { type: 'integer' }, two: { type: 'integer' } },
                     required: ['one', 'two'],
                 });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
 
             it('it should generate schema for object with props of different types', () => {
-                const schema = createSchema({ one: 1, two: 'second' });
+                const data = { one: 1, two: 'second' };
+                const schema = createSchema(data);
                 expect(schema).toEqual({
                     type: 'object',
                     properties: { one: { type: 'integer' }, two: { type: 'string' } },
                     required: ['one', 'two'],
                 });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
 
             it('it should generate schema for object with props of different types w/o required', () => {
-                const schema = createSchema({ one: 1, two: 'second' }, { noRequired: true });
+                const data = { one: 1, two: 'second' };
+                const schema = createSchema(data, { noRequired: true });
                 expect(schema).toEqual({
                     type: 'object',
                     properties: { one: { type: 'integer' }, two: { type: 'string' } },
                 });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
+            });
+
+            it('it should generate schema for object with allowing additional props', () => {
+                const data = { one: 1, two: 2 };
+                const schema = createSchema(data, {additionalProperties: true});
+                expect(schema).toEqual({
+                    type: 'object',
+                    properties: { one: { type: 'integer' }, two: { type: 'integer' } },
+                    required: ['one', 'two'],
+                    additionalProperties: true,
+                });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
+            });
+        });
+
+        describe('restrictive nulls', () => {
+            it.each([[[], [1], {}, {a: 1}, "a", 1, 1.2, true]])('should build schema with nullable false without restrictiveNulls', (s) => {
+                const schema = createSchema(s, {restrictiveNulls: true});
+                expect(schema.nullable).toBeFalsy();
+                const validate = ajv.compile(schema);
+                expect(validate(s)).toBeTruthy();
+            });
+            it.each([null, undefined])('should build schema with nullable true with restrictiveNulls', (s) => {
+                const schema = createSchema(s, {restrictiveNulls: true});
+                expect(schema.nullable).toBeTruthy();
+                // Ajv does not validate undefined as nulls!
+                if(s !== undefined) {
+                    const validate = ajv.compile(schema);
+                    expect(validate(s)).toBeTruthy();
+                }
             });
         });
 
         describe('nested array', () => {
             it('should generate schema for nested arrays', () => {
-                const schema = createSchema([1, [2.1], [[3]]]);
+                const data = [1, [2.1], [[3]]];
+                const schema = createSchema(data);
                 expect(schema).toEqual({
                     type: 'array',
                     items: {
@@ -124,10 +229,13 @@ describe('SchemaBuilder', () => {
                         ],
                     },
                 });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
 
             it('should generate schema for nested arrays and simplify anyOf', () => {
-                const schema = createSchema([1, 'some string', null, [2, 'some other string', {}], [[3.1]]]);
+                const data = [1, 'some string', null, [2, 'some other string', {}], [[3.1]]];
+                const schema = createSchema(data);
                 expect(schema).toEqual({
                     type: 'array',
                     items: {
@@ -154,21 +262,27 @@ describe('SchemaBuilder', () => {
                         ],
                     },
                 });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
         });
 
         describe('nested objects/arrays', () => {
             it('should combine object schemas and respect required property', () => {
-                const schema = createSchema({
+                const data = {
                     one: 1,
                     two: 'second',
                     three: { four: 5, five: [5], six: null, seven: [{}, { eight: 1.1 }, { nine: 'nine' }] },
-                });
+                };
+                const schema = createSchema(data);
                 expect(schema).toMatchSnapshot();
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
 
             it('should generate schema for nested object with props of different types w/o required', () => {
-                const schema = createSchema({ one: 1, two: { a: 'value' } }, { noRequired: true });
+                const data = { one: 1, two: { a: 'value' } }
+                const schema = createSchema(data, { noRequired: true });
                 expect(schema).toEqual({
                     type: 'object',
                     properties: {
@@ -176,12 +290,14 @@ describe('SchemaBuilder', () => {
                         two: { type: 'object', properties: { a: { type: 'string' } } },
                     },
                 });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
         });
 
         describe('all cases combined', () => {
             it('should generate valid schemas for complex objects', () => {
-                const schema = createSchema([
+                const data = [
                     {
                         lvl1PropNum: 1,
                         lvl1PropStr: 'second',
@@ -203,13 +319,15 @@ describe('SchemaBuilder', () => {
                     { lvl1PropStr: 'one' },
                     { lvl1PropNum: 1.2, lvl1PropStr: 'one' },
                     { lvl1PropStr: 'one', lvl1PropObj1: { lvl2PropArr: [2.3, null, 'some string', false] } },
-                ]);
-
+                ];
+                const schema = createSchema(data);
                 expect(schema).toMatchSnapshot();
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
 
             it('should consider value as required if it is present in all objects', async () => {
-                const val = [
+                const data = [
                     {
                         arr: [
                             {
@@ -228,7 +346,7 @@ describe('SchemaBuilder', () => {
                         ],
                     },
                 ];
-                const schema = createSchema(val);
+                const schema = createSchema(data);
                 expect(schema).toEqual({
                     type: 'array',
                     items: {
@@ -252,14 +370,17 @@ describe('SchemaBuilder', () => {
                         required: ['arr'],
                     },
                 });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
 
             it('should generate schema for array of objects w/o required', () => {
-                const schema = createSchema(
-                    [
+                const data = [
                         { one: 'a', two: 'b' },
                         { one: 'aa', two: 'bb' },
-                    ],
+                    ]
+                const schema = createSchema(
+                    data,
                     { noRequired: true }
                 );
                 expect(schema).toEqual({
@@ -272,6 +393,8 @@ describe('SchemaBuilder', () => {
                         },
                     },
                 });
+                const validate = ajv.compile(schema);
+                expect(validate(data)).toBeTruthy();
             });
         });
 
@@ -354,11 +477,16 @@ describe('SchemaBuilder', () => {
 
     describe('createCompoundSchema', () => {
         it('should create compound schema from multiple inputs', () => {
-            const schema = createCompoundSchema([{ age: 35 }, { age: 19, name: 'John' }, { age: 23, admin: true }]);
+            const dataArr = [{ age: 35 }, { age: 19, name: 'John' }, { age: 23, admin: true }]
+            const schema = createCompoundSchema(dataArr);
             expect(schema).toEqual({
                 type: 'object',
                 properties: { admin: { type: 'boolean' }, age: { type: 'integer' }, name: { type: 'string' } },
                 required: ['age'],
+            });
+            const validate = ajv.compile(schema);
+            dataArr.forEach(data => {
+                expect(validate(data)).toBeTruthy();
             });
         });
     });
@@ -415,6 +543,164 @@ describe('SchemaBuilder', () => {
                 { type: ValueType.Boolean },
             ]);
             expect(merged).toEqual({ type: ['boolean', 'number', 'string'] });
+        });
+
+        it('should merge arrays', () => {
+            const merged = mergeSchemas([{ type: ValueType.Array, items: {type: ValueType.String} }, { type: ValueType.Array, items: {type: ValueType.Number} }]);
+            expect(merged).toEqual({ type: ValueType.Array, items: {type: [ValueType.Number, ValueType.String]} });
+        });
+
+        it('should merge arrays with minItems', () => {
+            const merged = mergeSchemas([{ type: ValueType.Array, items: {type: ValueType.String}, minItems: 4 }, { type: ValueType.Array, items: {type: ValueType.Number}, minItems: 2 }]);
+            expect(merged).toEqual({ type: ValueType.Array, items: {type: [ValueType.Number, ValueType.String]}, minItems: 2 });
+        });
+
+        it('should merge arrays with minItems', () => {
+            const merged = mergeSchemas([{ type: ValueType.Array, items: {type: ValueType.String}, minItems: 4 }, { type: ValueType.Array, items: {type: ValueType.Number}, minItems: 2 }], {minItemsOverride: 1});
+            expect(merged).toEqual({ type: ValueType.Array, items: {type: [ValueType.Number, ValueType.String]}, minItems: 1 });
+        });
+
+        it('should merge nullable false schemas if both not nullable', () => {
+            const merged = mergeSchemas([{ type: ValueType.Number, nullable: false }, { type: ValueType.String, nullable: false }]);
+            expect(merged).toEqual({ type: ['number', 'string'], nullable: false });
+        });
+
+        it('should merge nullable false schemas if any of them is nullable', () => {
+            const merged = mergeSchemas([{ type: ValueType.Number, nullable: false }, { type: ValueType.String }]);
+            expect(merged).toEqual({ type: ['number', 'string'] });
+        });
+
+        it('should merge nullable false schemas if any of them is nullable and restrictiveNulls', () => {
+            const merged = mergeSchemas([{ type: ValueType.Number, nullable: false }, { type: ValueType.String }], {restrictiveNulls: true});
+            expect(merged).toEqual({
+                anyOf: [
+                    { type: ValueType.Number, nullable: false },
+                    { type: ValueType.String },
+                ],
+            });
+        });
+
+        it('should merge nullable false arrays', () => {
+            const merged = mergeSchemas([{ type: ValueType.Array, items: {type: ValueType.String}, nullable: false }, { type: ValueType.Array, items: {type: ValueType.Number}, nullable: false }], {minItemsOverride: 1});
+            expect(merged).toEqual({ type: ValueType.Array, items: {type: [ValueType.Number, ValueType.String]}, nullable: false });
+        });
+
+        it('should not merge nullable difference arrays in restrictiveNulls mode', () => {
+            const merged = mergeSchemas([{ type: ValueType.Array, items: {type: ValueType.String}, nullable: false }, { type: ValueType.Array, items: {type: ValueType.Number}, nullable: true }], {restrictiveNulls: true});
+            expect(merged).toEqual({
+                anyOf: [
+                    { type: ValueType.Array, items: {type: ValueType.String}, nullable: false },
+                    { type: ValueType.Array, items: {type: ValueType.Number} },
+                ],
+            });
+        });
+
+        it('should still merge nullable difference arrays in restrictiveNulls mode if they are same type', () => {
+            const merged = mergeSchemas([
+                { type: ValueType.Array, items: {type: ValueType.String}, nullable: false },
+                { type: ValueType.Array, items: {type: ValueType.String}, nullable: true }
+            ], {restrictiveNulls: true});
+            expect(merged).toEqual({
+                type: ValueType.Array,
+                items: {type: ValueType.String},
+                nullable: false
+            });
+        });
+
+        it('should merge nullable false objects', () => {
+            const merged = mergeSchemas([
+                { type: ValueType.Object, properties: {prop1: {type: ValueType.String}}, nullable: false },
+                { type: ValueType.Object, properties: {prop1: {type: ValueType.Number}}, nullable: false }
+            ], {restrictiveNulls: true});
+            expect(merged).toEqual({
+                type: ValueType.Object,
+                properties: {prop1: {type: [ValueType.Number, ValueType.String]}},
+                nullable: false
+            });
+        });
+
+        it('should not merge nullable difference objects in restrictiveNulls mode', () => {
+            const merged = mergeSchemas([
+                { type: ValueType.Object, properties: {prop1: {type: ValueType.String}}, nullable: false },
+                { type: ValueType.Object, properties: {prop1: {type: ValueType.Number}}, nullable: true }
+            ], {restrictiveNulls: true});
+            expect(merged).toEqual({
+                anyOf: [
+                    { type: ValueType.Object, properties: {prop1: {type: ValueType.String}}, nullable: false },
+                    { type: ValueType.Object, properties: {prop1: {type: ValueType.Number}} }
+                ],
+            });
+        });
+
+        it('should still merge nullable difference objects in restrictiveNulls mode 1', () => {
+            const merged = mergeSchemas([
+                { type: ValueType.Object, properties: { prop1: { type: ValueType.String, nullable: false } } },
+                { type: ValueType.Object, properties: { prop1: { type: ValueType.String, nullable: true } } },
+            ], { restrictiveNulls: true });
+            expect(merged).toEqual({
+                    type: ValueType.Object,
+                    properties: {prop1: {type: ValueType.String, nullable: false}},
+                });
+        });
+        it('should still merge nullable difference objects in non restrictiveNulls mode', () => {
+            const merged = mergeSchemas([
+                { type: ValueType.Object, properties: { prop1: { type: ValueType.String, nullable: false } } },
+                { type: ValueType.Object, properties: { prop1: { type: ValueType.String, nullable: true } } },
+            ], { restrictiveNulls: false });
+            expect(merged).toEqual({
+                type: ValueType.Object,
+                properties: {prop1: {type: ValueType.String}},
+            });
+        });
+        it('should still merge nullable difference objects in restrictiveNulls mode 2', () => {
+            const merged = mergeSchemas([
+                { type: ValueType.Object, properties: { prop1: { type: ValueType.String } }, nullable: false },
+                { type: ValueType.Object, properties: { prop1: { type: ValueType.Integer } }, nullable: true },
+            ], { restrictiveNulls: true });
+            expect(merged).toEqual({
+                anyOf: [
+                    { type: ValueType.Object, properties: { prop1: { type: ValueType.String } }, nullable: false },
+                    { type: ValueType.Object, properties: { prop1: { type: ValueType.Integer } } },
+                ],
+            });
+        });
+
+        it('should keep additional properties', () => {
+            const merged = mergeSchemas([
+                { type: ValueType.Object, properties: { prop1: { type: ValueType.String } }, additionalProperties: true },
+                { type: ValueType.Object, properties: { prop1: { type: ValueType.Integer } }, additionalProperties: true },
+            ]);
+            expect(merged).toEqual(
+                {
+                    type: ValueType.Object,
+                    properties: { prop1: { type: [ValueType.Integer, ValueType.String] } },
+                },
+            );
+        });
+        it('should keep additional properties v2', () => {
+            const merged = mergeSchemas([
+                { type: ValueType.Object, properties: { prop1: { type: ValueType.String } }, additionalProperties: false },
+                { type: ValueType.Object, properties: { prop1: { type: ValueType.Integer } }, additionalProperties: false },
+            ]);
+            expect(merged).toEqual(
+                {
+                    type: ValueType.Object,
+                    properties: { prop1: { type: [ValueType.Integer, ValueType.String] } },
+                    additionalProperties: false
+                },
+            );
+        });
+        it('should prioritize additional properties', () => {
+            const merged = mergeSchemas([
+                { type: ValueType.Object, properties: { prop1: { type: ValueType.String } }, additionalProperties: true },
+                { type: ValueType.Object, properties: { prop1: { type: ValueType.Integer } }, additionalProperties: false},
+            ]);
+            expect(merged).toEqual(
+                {
+                    type: ValueType.Object,
+                    properties: { prop1: { type: [ValueType.Integer, ValueType.String] } },
+                },
+            );
         });
     });
 

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "target": "ES2017",
         "lib": ["ES2019"],
+        "rootDir": "./src",
         "outDir": "dist",
         "module": "commonjs",
         "moduleResolution": "node",

--- a/yarn.lock
+++ b/yarn.lock
@@ -725,6 +725,16 @@ agent-base@6:
   dependencies:
     debug "4"
 
+ajv@^8.12.0:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ansi-escapes@^4.2.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.1.tgz#a5c47cc43181f1f38ffd7076837700d395522a61"
@@ -732,12 +742,7 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.11.0"
 
-ansi-regex@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
-  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
-
-ansi-regex@^5.0.1:
+ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -1200,6 +1205,11 @@ expect@^27.5.1:
     jest-get-type "^27.5.1"
     jest-matcher-utils "^27.5.1"
     jest-message-util "^27.5.1"
+
+fast-deep-equal@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
@@ -1950,7 +1960,12 @@ json-parse-even-better-errors@^2.3.0:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.0.tgz#371873c5ffa44304a6ba12419bcfa95f404ae081"
   integrity sha512-o3aP+RsWDJZayj1SbHNQAI8x0v3T3SKiGoZlNYfbUP1S3omJQ6i9CnqADqkSPaOAxwua4/1YWx5CM7oiChJt2Q==
 
-json5@2.x, json5@^2.1.2, json5@^2.2.2:
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
+json5@2.x, json5@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -1990,12 +2005,7 @@ lodash.memoize@4.x:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash@^4.17.19:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-lodash@^4.7.0:
+lodash@^4.17.19, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2063,17 +2073,12 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-minimatch@^3.0.4:
+minimatch@^3.0.4, minimatch@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
-
-minimist@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
-  integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
 
 ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
@@ -2246,7 +2251,7 @@ psl@^1.1.33:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
   integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
 
-punycode@^2.1.1:
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
@@ -2265,6 +2270,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 requires-port@^1.0.0:
   version "1.0.0"
@@ -2593,6 +2603,13 @@ update-browserslist-db@^1.0.10:
   dependencies:
     escalade "^3.1.1"
     picocolors "^1.0.0"
+
+uri-js@^4.2.2:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
+  dependencies:
+    punycode "^2.1.0"
 
 url-parse@^1.5.3:
   version "1.5.10"


### PR DESCRIPTION
Hy!

This got lot bigger than I expected... And it is not fully consistent, but working.

Merging schemas should go two directions. There is a use-case when I have a lot of things, and I want to find the most suitable schema to them. For this, I want to restrict the merge. So if I have a field in one schema that is nullable, and the same field in on other schema is non-nullable, I want to make the merged field non-nullable. But there is an other use-case, when I want to find out if a schema is a subschema of an another or not. In this case I want to merge permissive, so merging a non-nullable with a nullable schould be nullable. I found out this fundamentally easy thing at the end of my last test-case, and I didn't have time to properly refactor the whole thing, so I committed this as-is bcs it is working already, and covers a LOT more functionality than the prev code, and I think it is a good starting point.

I think the test are describing what works and how. I think in most cases this will be the intended behavior.

I'm open for further discussions and cleanups.