### PR TITLE
feat: option noAdditionalProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,23 @@ isSubset(
 ```
 <hr/>
 You can find more examples in the unit tests.
+
+### Options
+#### noAdditionalProperties 
+Add `additionalProperties=false` to all object types
+```ts
+import { createSchema } from 'genson-js';
+const schema = createSchema({ one: 1, two: 'second' }, { noAdditionalProperties: true });
+```
+The following schema will be created:
+```ts
+{
+    type: 'object',
+    additionalProperties: false,
+    properties: { one: { type: 'integer' }, two: { type: 'string' } },
+    required: [
+        "one",
+        "two",
+    ]
+}
+```

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,10 +14,12 @@ export type Schema = {
     properties?: Record<string, Schema>;
     required?: string[];
     anyOf?: Array<Schema>;
+    additionalProperties?: boolean;
 };
 
 export type SchemaGenOptions = {
-    noRequired: boolean;
+    noRequired?: boolean;
+    noAdditionalProperties?: boolean;
 };
 
 export type SchemaComparisonOptions = {

--- a/tests/schema-builder.spec.ts
+++ b/tests/schema-builder.spec.ts
@@ -93,6 +93,18 @@ describe('SchemaBuilder', () => {
                     properties: { one: { type: 'integer' }, two: { type: 'string' } },
                 });
             });
+            it('it should generate schema for object with additionalProperties=false ', () => {
+                const schema = createSchema({ one: 1, two: 'second' }, { noAdditionalProperties: true });
+                expect(schema).toEqual({
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: { one: { type: 'integer' }, two: { type: 'string' } },
+                    required: [
+                        "one",
+                        "two",
+                    ]
+                });
+            });
         });
 
         describe('nested array', () => {
@@ -238,6 +250,54 @@ describe('SchemaBuilder', () => {
                                 type: 'array',
                                 items: {
                                     type: 'object',
+                                    properties: {
+                                        prop1: {
+                                            type: 'string',
+                                        },
+                                        prop2: {
+                                            type: 'string',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        required: ['arr'],
+                    },
+                });
+            });
+
+            it('should consider value with additionalProperties=false in all objects', async () => {
+                const val = [
+                    {
+                        arr: [
+                            {
+                                prop1: 'test string',
+                            },
+                            {
+                                prop2: 'test string',
+                            },
+                        ],
+                    },
+                    {
+                        arr: [
+                            {
+                                prop1: 'test',
+                            },
+                        ],
+                    },
+                ];
+                const schema = createSchema(val, { noAdditionalProperties: true });
+                expect(schema).toEqual({
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        additionalProperties: false,
+                        properties: {
+                            arr: {
+                                type: 'array',
+                                items: {
+                                    type: 'object',
+                                    additionalProperties: false,
                                     properties: {
                                         prop1: {
                                             type: 'string',


### PR DESCRIPTION
Adding option  `noAdditionalProperties`
Add `additionalProperties=false` to all object types
```ts
import { createSchema } from 'genson-js';
const schema = createSchema({ one: 1, two: 'second' }, { noAdditionalProperties: true });
```
The following schema will be created:
```ts
{
    type: 'object',
    additionalProperties: false,
    properties: { one: { type: 'integer' }, two: { type: 'string' } },
    required: [
        "one",
        "two",
    ]
}
```